### PR TITLE
Update Sender.php

### DIFF
--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -82,7 +82,7 @@ class Sender {
      */
     public function sendNoRetry(Message $message, $registrationId) {
         if(empty($registrationId))
-            throw new \InvalidArgumentException('registrationId was null');
+            throw new \InvalidArgumentException('registrationId can\'t be empty');
 
         $body = Constants::$PARAM_REGISTRATION_ID . '=' . $registrationId;
 


### PR DESCRIPTION
The \InvalidArgumentException should be thrown on empty($registrationId) instead of is_null($registrationId) because a empty variable is not valid as $registrationId.
