### PR TITLE
Formally depend upon PHP and curl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,9 @@
 	},
     "autoload": {
         "psr-0": { "PHP_GCM": "src/" }
+    },
+    "require": {
+        "php": ">=5.3.29",
+        "ext-curl": "*"
     }
 }


### PR DESCRIPTION
To ensure we have curl at compose-time, rather than nasty run-time crashes. :)