### PR TITLE
Fix delayedWhileIdle default, updateStatus exception, minor docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Composer is the easiest way to manage dependencies in your project. Create a fil
 ```json
 {
     "require": {
-        "php-gcm/php-gcm": "1.1.0"
+        "php-gcm/php-gcm": "^1.1.0"
     }
 }
 ```

--- a/src/PHP_GCM/Message.php
+++ b/src/PHP_GCM/Message.php
@@ -36,7 +36,7 @@ class Message {
      * @param array $data
      * @param string $restrictedPackageName
      */
-    public function __construct($collapseKey = '', array $data = array(), $timeToLive = -1, $delayWhileIdle = '',
+    public function __construct($collapseKey = '', array $data = array(), $timeToLive = -1, $delayWhileIdle = null,
                                 $restrictedPackageName = '', $dryRun = false) {
         $this->collapseKey = $collapseKey;
 

--- a/src/PHP_GCM/Message.php
+++ b/src/PHP_GCM/Message.php
@@ -36,7 +36,7 @@ class Message {
      * @param array $data
      * @param string $restrictedPackageName
      */
-    public function __construct($collapseKey = '', array $data = array(), $timeToLive = -1, $delayWhileIdle = null,
+    public function __construct($collapseKey = '', array $data = array(), $timeToLive = -1, $delayWhileIdle = false,
                                 $restrictedPackageName = '', $dryRun = false) {
         $this->collapseKey = $collapseKey;
 

--- a/src/PHP_GCM/MulticastResult.php
+++ b/src/PHP_GCM/MulticastResult.php
@@ -34,7 +34,6 @@ class MulticastResult {
      * @param int $failure
      * @param int $canonicalIds
      * @param string $multicastId
-     * @param array $results
      * @param array $retryMulticastIds
      */
     public function __construct($success, $failure, $canonicalIds, $multicastId, array $retryMulticastIds = array()) {

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -329,7 +329,6 @@ class Sender {
         if(count($results) != count($unsentRegIds)) {
             // should never happen, unless there is a flaw in the algorithm
             throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . $results .
-                '; unsentRegIds: ' + $unsentRegIds);
         }
 
         $newUnsentRegIds = array();

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -89,11 +89,12 @@ class Sender {
      * @param Message $message to be sent, including the device's registration id.
      * @param string $registrationId device where the message will be sent.
      *
-     * @return result of the post, or {@literal null} if the GCM service was
-     *         unavailable.
+     * @return Result|null result of the post, or {@literal null} if the GCM service
+     *         was unavailable.
      *
-     * @throws InvalidRequestException if GCM didn't returned a 200 or 503 status.
+     * @throws InvalidRequestException if GCM didn't return a 200 or 503 status.
      * @throws \InvalidArgumentException if registrationId is {@literal null}.
+     * @throws \Exception if message could not be sent.
      */
     public function sendNoRetry(Message $message, $registrationId) {
         if(empty($registrationId))
@@ -240,7 +241,7 @@ class Sender {
      * Sends a message without retrying in case of service unavailability. See
      * sendMulti() for more info.
      *
-     * @return {@literal true} if the message was sent successfully,
+     * @return bool {@literal true} if the message was sent successfully,
      *         {@literal false} if it failed but could be retried.
      *
      * @throws \InvalidArgumentException if registrationIds is {@literal null} or
@@ -318,8 +319,8 @@ class Sender {
      * Updates the status of the messages sent to devices and the list of devices
      * that should be retried.
      *
-     * @param array unsentRegIds list of devices that are still pending an update.
-     * @param array allResults map of status that will be updated.
+     * @param array $unsentRegIds list of devices that are still pending an update.
+     * @param array $allResults map of status that will be updated.
      * @param MulticastResult multicastResult result of the last multicast sent.
      *
      * @return array updated version of devices that should be retried.
@@ -329,6 +330,7 @@ class Sender {
         if(count($results) != count($unsentRegIds)) {
             // should never happen, unless there is a flaw in the algorithm
             throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . $results .
+                '; unsentRegIds: ' . implode(',', $unsentRegIds));
         }
 
         $newUnsentRegIds = array();


### PR DESCRIPTION
Apologies for the mega-PR; can split into multiple if that makes more sense.

* The current best practice for Composer is to use the caret operator for SemVer-compliant libraries, which I'm guessing this one is, so a composer update will get any new non-breaking changes.
* Could've set the default to null, but as of 4.2.2 (not sure if Android or Play Services version, probably the former) that would've delayed messages while idle, which would be a BC break here. With the default to false, a this PR is a patch rather than a major release.
* For updateStatus(), looked like the \RuntimeException would've crashed the caller. Now, instead, it shows a useful error message, assuming the arg types are correct and the unsentRegIds var is indeed an array.
* Docblocks now don't throw off red flags in PhpStorm...there were a few issues where params/returns weren't matching that are now fixed.
* For the Message constructor, the evaluation of is_null() on '' meant that the default was to include the delayed_while_idle param and set it to false, rather than not include it in the request body at all. The associated commits for that clarify the behavior, so it's obvious that messages aren't delayed while idle.
