### PR TITLE
Force $registrationIds to be non-associative.

### DIFF
--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -192,7 +192,7 @@ class Sender {
         // results by registration id, it will be updated after each attempt
         // to send the messages
         $results = array();
-        $unsentRegIds = $registrationIds;
+        $unsentRegIds = array_values($registrationIds);
 
         $multicastIds = array();
 


### PR DESCRIPTION
Associative arrays, or those that don't have sequential keys starting at 0, will encode as a JSON object instead of a JSON array when passed through json_encode(), causing problems for the GCM service.