### PR TITLE
Add content_available and priority to the message

### DIFF
--- a/src/PHP_GCM/AggregateResult.php
+++ b/src/PHP_GCM/AggregateResult.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace PHP_GCM;
+
+/**
+ * Aggregate results of GCM multicast message requests.
+ */
+class AggregateResult {
+
+  private $success;
+  private $failure;
+  private $canonicalIds;
+  private $results;
+  private $multicastResults;
+  private $retryMulticastIds;
+
+  /**
+   * @param MulticastResult[] $multicastResults
+   */
+  public function __construct(array $multicastResults = array()) {
+    $this->multicastResults = $multicastResults;
+
+    $this->results = [];
+    $this->retryMulticastIds = [];
+    $this->success = $this->failure = $this->canonicalIds = 0;
+    foreach($multicastResults as $multicastResult) {
+      $this->success += $multicastResult->getSuccess();
+      $this->failure += $multicastResult->getFailure();
+      $this->canonicalIds += $multicastResult->getCanonicalIds();
+      array_splice($this->results, count($this->results), 0, $multicastResult->getResults());
+      array_splice($this->retryMulticastIds, count($this->retryMulticastIds), 0, $multicastResult->getRetryMulticastIds());
+    }
+  }
+
+  /**
+   * Gets the number of successful messages.
+   *
+   * @return int
+   */
+  public function getSuccess() {
+    return $this->success;
+  }
+
+  /**
+   * Gets the total number of messages sent, regardless of the status.
+   *
+   * @return int
+   */
+  public function getTotal() {
+    return $this->success + $this->failure;
+  }
+
+  /**
+   * Gets the number of failed messages.
+   *
+   * @return int
+   */
+  public function getFailure() {
+    return $this->failure;
+  }
+
+  /**
+   * Gets the number of successful messages that also returned a canonical
+   * registration id.
+   *
+   * @return int
+   */
+  public function getCanonicalIds() {
+    return $this->canonicalIds;
+  }
+
+  /**
+   * Gets the results of each individual message
+   *
+   * @return array
+   */
+  public function getResults() {
+    return $this->results;
+  }
+
+  /**
+   * Gets additional ids if more than one multicast message was sent.
+   *
+   * @return array
+   */
+  public function getMulticastResults() {
+    return $this->multicastResults;
+  }
+
+  /**
+   * Gets the multicast id of the first try.
+   *
+   * @return string
+   */
+  public function getMulticastId() {
+    return !!count($this->multicastResults) ? $this->multicastResults[0]->getMulticastId() : 0;
+  }
+
+  /**
+   * Gets additional ids if more than one multicast message was sent.
+   *
+   * @return array
+   */
+  public function getRetryMulticastIds() {
+    return $this->retryMulticastIds;
+  }
+}

--- a/src/PHP_GCM/Message.php
+++ b/src/PHP_GCM/Message.php
@@ -25,6 +25,8 @@ class Message {
   const NOTIFICATION_BODY_LOC_ARGS = 'body_loc_args';
   const NOTIFICATION_TITLE_LOC_KEY = 'title_loc_key';
   const NOTIFICATION_TITLE_LOC_ARGS = 'title_loc_args';
+  const CONTENT_AVAILABLE = 'content_available';
+  const PRIORITY = 'priority';
 
   private $collapseKey;
   private $delayWhileIdle;
@@ -33,6 +35,8 @@ class Message {
   private $data;
   private $restrictedPackageName;
   private $notification;
+  private $contentAvailable;
+  private $priority;
 
   /**
    * Message Constructor
@@ -173,6 +177,36 @@ class Message {
     return $this->notification;
   }
 
+  /**
+   * Sets the contentAvailable property
+   *
+   * @param $contentAvailable
+   * @return $this
+   */
+  public function contentAvailable($contentAvailable) {
+    $this->contentAvailable = $contentAvailable;
+    return $this;
+  }
+
+  public function getContentAvailable() {
+    return $this->contentAvailable;
+  }
+
+  /**
+   * Sets the priority property
+   *
+   * @param $priority
+   * @return $this
+   */
+  public function priority($priority) {
+    $this->priority = $priority;
+    return $this;
+  }
+
+  public function getPriority() {
+    return $this->priority;
+  }
+
   public function build($recipients) {
     $message = array();
 
@@ -194,6 +228,14 @@ class Message {
 
     if ($this->restrictedPackageName != '') {
       $message[self::RESTRICTED_PACKAGE_NAME] = $this->restrictedPackageName;
+    }
+
+    if ($this->contentAvailable) {
+      $message[self::CONTENT_AVAILABLE] = $this->contentAvailable;
+    }
+
+    if ($this->priority) {
+      $message[self::PRIORITY] = $this->priority;
     }
 
     if (!is_null($this->data) && count($this->data) > 0) {


### PR DESCRIPTION
To properly support GCM to iOS notifications I found that content_available and/or priority are required as part of the payload. Added is the commit that adds these parameters to the Message class