### PR TITLE
store the deviceId for each Result in a MulticastResult

### DIFF
--- a/src/PHP_GCM/AggregateResult.php
+++ b/src/PHP_GCM/AggregateResult.php
@@ -72,7 +72,7 @@ class AggregateResult {
   /**
    * Gets the results of each individual message
    *
-   * @return array
+   * @return Result[]
    */
   public function getResults() {
     return $this->results;
@@ -81,7 +81,7 @@ class AggregateResult {
   /**
    * Gets additional ids if more than one multicast message was sent.
    *
-   * @return array
+   * @return MulticastResult[]
    */
   public function getMulticastResults() {
     return $this->multicastResults;

--- a/src/PHP_GCM/MulticastResult.php
+++ b/src/PHP_GCM/MulticastResult.php
@@ -34,10 +34,11 @@ class MulticastResult {
   /**
    * Add a result to the result property
    *
+   * @param string $device
    * @param Result $result
    */
-  public function addResult(Result $result) {
-    $this->results[] = $result;
+  public function addResult($device, Result $result) {
+    $this->results[$device] = $result;
   }
 
   /**
@@ -89,7 +90,7 @@ class MulticastResult {
   /**
    * Gets the results of each individual message
    *
-   * @return array
+   * @return array Mapping of deviceId -> Result
    */
   public function getResults() {
     return $this->results;

--- a/src/PHP_GCM/MulticastResult.php
+++ b/src/PHP_GCM/MulticastResult.php
@@ -34,11 +34,11 @@ class MulticastResult {
   /**
    * Add a result to the result property
    *
-   * @param string $device
+   * @param string $registrationId
    * @param Result $result
    */
-  public function addResult($device, Result $result) {
-    $this->results[$device] = $result;
+  public function addResult($registrationId, Result $result) {
+    $this->results[$registrationId] = $result;
   }
 
   /**
@@ -90,7 +90,7 @@ class MulticastResult {
   /**
    * Gets the results of each individual message
    *
-   * @return array Mapping of deviceId -> Result
+   * @return array Mapping of registrationId -> Result
    */
   public function getResults() {
     return $this->results;

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -323,7 +323,7 @@ class Sender {
     if(count($results) != count($unsentRegIds)) {
       // should never happen, unless there is a flaw in the algorithm
       throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . implode(', ', $results) .
-        '; unsentRegIds: ' . implode(', ', $unsentRegIds);
+        '; unsentRegIds: ' . implode(', ', $unsentRegIds));
     }
 
     $newUnsentRegIds = array();

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -322,8 +322,8 @@ class Sender {
     $results = $multicastResult->getResults();
     if(count($results) != count($unsentRegIds)) {
       // should never happen, unless there is a flaw in the algorithm
-      throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . $results .
-        '; unsentRegIds: ' . $unsentRegIds);
+      throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . implode(', ', $results) .
+        '; unsentRegIds: ' . implode(', ', $unsentRegIds);
     }
 
     $newUnsentRegIds = array();

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -321,8 +321,11 @@ class Sender {
   private function updateStatus($unsentRegIds, &$allResults, MulticastResult $multicastResult) {
     $results = $multicastResult->getResults();
     if(count($results) != count($unsentRegIds)) {
+      $currentResults = array_map(function($item){
+        return var_export($item, true);
+      }, $results);
       // should never happen, unless there is a flaw in the algorithm
-      throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . implode(', ', $results) .
+      throw new \RuntimeException('Internal error: sizes do not match. currentResults: ' . implode(', ', $currentResults) .
         '; unsentRegIds: ' . implode(', ', $unsentRegIds));
     }
 

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -136,7 +136,7 @@ class Sender {
 
       $result = new MulticastResult($success, $failure, $canonicalIds, $multicastIds[0], $multicastIds);
       foreach ($registrationIds as $registrationId) {
-        $result->addResult($results[$registrationId]);
+        $result->addResult($registrationId, $results[$registrationId]);
       }
 
       $multicastResults[] = $result;
@@ -288,6 +288,7 @@ class Sender {
     if(isset($response[self::RESULTS])){
       $individualResults = $response[self::RESULTS];
 
+      $i = 0;
       foreach($individualResults as $singleResult) {
         $messageId = isset($singleResult[self::MESSAGE_ID]) ? $singleResult[self::MESSAGE_ID] : null;
         $canonicalRegId = isset($singleResult[self::REGISTRATION_ID]) ? $singleResult[self::REGISTRATION_ID] : null;
@@ -298,7 +299,8 @@ class Sender {
         $result->setCanonicalRegistrationId($canonicalRegId);
         $result->setErrorCode($error);
 
-        $multicastResult->addResult($result);
+        $multicastResult->addResult($devices[$i], $result);
+        ++$i;
       }
     }
 

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -27,6 +27,7 @@ class Sender {
   const DEVICE_GROUP_NOTIFICATION_KEY = 'notification_key';
 
   private $key;
+  private $endpoint;
   private $retries;
   private $certificatePath;
 
@@ -35,8 +36,9 @@ class Sender {
    *
    * @param string $key API key obtained through the Google API Console.
    */
-  public function __construct($key) {
+  public function __construct($key, $endpoint=self::GCM_ENDPOINT) {
     $this->key = $key;
+    $this->endpoint = $endpoint;
     $this->retries = 3;
     $this->certificatePath = null;
   }
@@ -258,7 +260,7 @@ class Sender {
 
   private function makeRequest(Message $message, array $registrationIds) {
     $ch = $this->getCurlRequest();
-    curl_setopt($ch, CURLOPT_URL, self::GCM_ENDPOINT);
+    curl_setopt($ch, CURLOPT_URL, $this->endpoint);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Authorization: key=' . $this->key));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $message->build($registrationIds));
     $response = curl_exec($ch);

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -301,7 +301,7 @@ class Sender {
         $result->setCanonicalRegistrationId($canonicalRegId);
         $result->setErrorCode($error);
 
-        $multicastResult->addResult($devices[$i], $result);
+        $multicastResult->addResult($registrationIds[$i], $result);
         ++$i;
       }
     }

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -330,7 +330,7 @@ class Sender {
     $newUnsentRegIds = array();
     for ($i = 0; $i < count($unsentRegIds); $i++) {
       $regId = $unsentRegIds[$i];
-      $result = $results[$i];
+      $result = $results[$regId];
       $allResults[$regId] = $result;
       $error = $result->getErrorCode();
 

--- a/tests/PHP_GCM/AggregateResultTest.php
+++ b/tests/PHP_GCM/AggregateResultTest.php
@@ -53,10 +53,10 @@ class AggregateResultTest extends \PHPUnit_Framework_TestCase {
 
   public function testGetResults() {
     $result = new MulticastResult(1, 2, 1, 'multicast-id', array());
-    $result->addResult(new Result());
+    $result->addResult('123', new Result());
 
     $this->assertTrue(is_array($result->getResults()));
-    $this->assertEquals(array(new Result()), $result->getResults());
+    $this->assertEquals(array('123' => new Result()), $result->getResults());
   }
 
   public function testGetRetryMulticastIds() {

--- a/tests/PHP_GCM/MulticastResultTest.php
+++ b/tests/PHP_GCM/MulticastResultTest.php
@@ -20,7 +20,7 @@ class MulticastResultTest extends \PHPUnit_Framework_TestCase {
     $result = new MulticastResult(1, 2, 1, 'multicast-id', array());
     $this->assertTrue(is_array($result->getResults()) && empty($result->getResults()));
 
-    $result->addResult(new Result());
+    $result->addResult('', new Result());
 
     $this->assertTrue(is_array($result->getResults()) && count($result->getResults()) == 1);
   }
@@ -57,10 +57,10 @@ class MulticastResultTest extends \PHPUnit_Framework_TestCase {
 
   public function testGetResults() {
     $result = new MulticastResult(1, 2, 1, 'multicast-id', array());
-    $result->addResult(new Result());
+    $result->addResult('123', new Result());
 
     $this->assertTrue(is_array($result->getResults()));
-    $this->assertEquals(array(new Result()), $result->getResults());
+    $this->assertEquals(array('123' => new Result()), $result->getResults());
   }
 
   public function testGetRetryMulticastIds() {


### PR DESCRIPTION
In order to deal with results (especially ERROR_NOT_REGISTERED) it is important to be able to retrieve the deviceId for a certain result. 

This commit modifies the MulticastResult so that it will use the deviceIds as array keys when storing the respective Result object, and thus the result of getResults will then also be an associative array there (deviceId => Result).

Edit: I also added support for a custom endpoint (like pushy.me)
