### PR TITLE
Support for encrypted payload

### DIFF
--- a/src/PHP_GCM/Message.php
+++ b/src/PHP_GCM/Message.php
@@ -27,6 +27,7 @@ class Message {
   const NOTIFICATION_TITLE_LOC_ARGS = 'title_loc_args';
   const CONTENT_AVAILABLE = 'content_available';
   const PRIORITY = 'priority';
+  const RAW_DATA = 'raw_data';
 
   private $collapseKey;
   private $delayWhileIdle;
@@ -37,6 +38,9 @@ class Message {
   private $notification;
   private $contentAvailable;
   private $priority;
+  private $rawData;
+  private $publicKey;
+  private $salt;
 
   /**
    * Message Constructor
@@ -196,6 +200,51 @@ class Message {
     return $this->priority;
   }
 
+  /**
+   * Sets the rawData property
+   *
+   * @param $rawData
+   * @return $this
+   */
+  public function rawData($rawData) {
+    $this->rawData = $rawData;
+    return $this;
+  }
+
+  public function getRawData() {
+    return $this->rawData;
+  }
+
+  /**
+   * Sets the publicKey property
+   *
+   * @param $publicKey
+   * @return $this
+   */
+  public function publicKey($publicKey) {
+    $this->publicKey = $publicKey;
+    return $this;
+  }
+
+  public function getPublicKey() {
+    return $this->publicKey;
+  }
+
+  /**
+   * Sets the salt property
+   *
+   * @param $salt
+   * @return $this
+   */
+  public function salt($salt) {
+    $this->salt = $salt;
+    return $this;
+  }
+
+  public function getSalt() {
+    return $this->salt;
+  }
+
   public function build($recipients) {
     $message = array();
 
@@ -249,6 +298,10 @@ class Message {
       $message[self::NOTIFICATION][self::NOTIFICATION_TITLE] = $this->notification->getTitle();
       $message[self::NOTIFICATION][self::NOTIFICATION_TITLE_LOC_ARGS] = $this->notification->getTitleLocArgs();
       $message[self::NOTIFICATION][self::NOTIFICATION_TITLE_LOC_KEY] = $this->notification->getTitleLocKey();
+    }
+
+    if (!empty($this->rawData)) {
+        $message[self::RAW_DATA] = $this->rawData;
     }
 
     return json_encode($message);

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -259,7 +259,15 @@ class Sender {
   private function makeRequest(Message $message, array $registrationIds) {
     $ch = $this->getCurlRequest();
     curl_setopt($ch, CURLOPT_URL, self::SEND_ENDPOINT);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Authorization: key=' . $this->key));
+    $headers = array('Content-Type: application/json', 'Authorization: key=' . $this->key);
+    if(!empty($message->getSalt()) && !empty($message->getPublicKey())) {
+      $headers = array_merge($headers, array(
+        'Encryption: salt=' . $message->getSalt(),
+        'Crypto-Key: dh=' . $message->getPublicKey(),
+        'Content-Encoding: aesgcm'
+      ));
+    }
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $message->build($registrationIds));
     $response = curl_exec($ch);
     $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/src/PHP_GCM/Sender.php
+++ b/src/PHP_GCM/Sender.php
@@ -260,7 +260,7 @@ class Sender {
     $ch = $this->getCurlRequest();
     curl_setopt($ch, CURLOPT_URL, self::SEND_ENDPOINT);
     $headers = array('Content-Type: application/json', 'Authorization: key=' . $this->key);
-    if(!empty($message->getSalt()) && !empty($message->getPublicKey())) {
+    if(!is_null($message->getSalt()) && !is_null($message->getPublicKey())) {
       $headers = array_merge($headers, array(
         'Encryption: salt=' . $message->getSalt(),
         'Crypto-Key: dh=' . $message->getPublicKey(),


### PR DESCRIPTION
User can set an (externally) encrypted payload as described in #22 to be used with Chrome.
